### PR TITLE
Implement delegated domain check

### DIFF
--- a/create-circle.js
+++ b/create-circle.js
@@ -12,6 +12,13 @@ async function apiRequest(url, options = null)
     }
 
     return await fetch(url, options ?? {})
+        .then(response => {
+            if (response.ok) {
+                return response;
+            }
+
+            throw new Error(`Error fetching ${url}: ${response.status} ${response.statusText}`);
+        })
         .then(response => response.json())
         .catch(error => {
             console.error(`Error fetching ${url}: ${error}`);
@@ -267,7 +274,12 @@ class MastodonApiClient extends ApiClient {
 
     async getUserIdFromHandle(handle) {
         const url = `https://${this._instance}/api/v1/accounts/lookup?acct=${handle.baseHandle}`;
-        const response = await apiRequest(url, null);
+        let response = await apiRequest(url, null);
+
+        if (!response) {
+            const url = `https://${this._instance}/api/v1/accounts/lookup?acct=${handle}`;
+            response = await apiRequest(url, null);
+        }
 
         if (!response) {
             return null;

--- a/image.js
+++ b/image.js
@@ -50,7 +50,7 @@ function render(users, selfUser) {
 				centerX - radius[layerIndex],
 				centerY - radius[layerIndex],
 				radius[layerIndex],
-				"@" + users[userNum].handle.name + "@" + users[userNum].handle.instance
+				"@" + users[userNum].handle
 			);
 
             userNum++;


### PR DESCRIPTION
The webfinger request should always work on the delegated instance, so we can check to see which instance we should send API requests to by first finding the hostname used for the "self" link in the webfinger response. I'm mutating the ``selfUser`` ``Handle`` object to edit the instance, and also adding a new property of it for the handle since with this change handles are not guaranteed to be @{name}@{instance}.

I've checked to see that this doesn't break requests for non-delegated Pleroma, Mastodon, and Misskey accounts, but feel free to check yourself.
I'm unfamiliar with Misskey's API and how they handle delegation in the search API endpoint, so I've left that unchanged.