### PR TITLE
Recognize Sharkey and Cutiekey as Misskey

### DIFF
--- a/create-circle.js
+++ b/create-circle.js
@@ -262,7 +262,9 @@ class ApiClient {
             software.name.includes("calckey") ||
             software.name.includes("foundkey") ||
             software.name.includes("magnetar") ||
-            software.name.includes("firefish")) {
+            software.name.includes("firefish") ||
+            software.name.includes("sharkey") ||
+            software.name.includes("cutiekey")) {
             const client = new MisskeyApiClient(instance);
             instanceTypeCache.set(instance, client);
             return client;


### PR DESCRIPTION
Sharkey is a Misskey fork, while Cutiekey is a Sharkey fork. Their Mastodon API is incomplete, so using Misskey API for them makes sense.